### PR TITLE
CMake: Fix installation directory of man pages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ install(
 
 install(
 	FILES pn.1
-	DESTINATION ${CMAKE_INSTALL_PREFIX}/man/man1
+	DESTINATION share/man/man1
 )
 
 if( HAVE_GAWK_H )


### PR DESCRIPTION
This used to install to `/usr/man` which isn't valid as confirmed under Alpine, Arch and Void Linux.

For example Void's xbps-src printed the following:
```
=> pn-0.9.0_1: running pre-pkg hook: 99-pkglint ...
=> ERROR: pn-0.9.0_1: /usr/man is forbidden, use /usr/share/man.
=> ERROR: pn-0.9.0_1: cannot continue with installation!
```
On [Alpine](https://git.alpinelinux.org/aports/tree/community/pn/APKBUILD#n53) and [Arch](https://github.com/dreemurrs-embedded/Pine64-Arch/blob/master/PKGBUILDS/sxmo/pn/PKGBUILD#L32) this was already being worked around by moving `/usr/man` under `/usr/share/`, so the files might as well be installed to the expected directory.